### PR TITLE
t/Makefile: stabilise parallel builds.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -27,34 +27,34 @@ all: $(BIN_DIR) $(TESTS)
 $(BIN_DIR):
 	mkdir $@
 
-$(BIN_DIR)/endian_test: endian_test.c
+$(BIN_DIR)/endian_test: endian_test.c $(BIN_DIR)
 	$(CC) $(CFLAGS) $< -o $@
 
-$(BIN_DIR)/unit_test_helpers: unit_test_helpers.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(SRC)/slow5_misc.h
+$(BIN_DIR)/unit_test_helpers: unit_test_helpers.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(SRC)/slow5_misc.h $(BIN_DIR)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ $(LDFLAGS)
 
-$(BIN_DIR)/unit_test_press: unit_test_press.c unit_test.h $(LIB)/libslow5.a
+$(BIN_DIR)/unit_test_press: unit_test_press.c unit_test.h $(LIB)/libslow5.a $(BIN_DIR)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ $(LDFLAGS)
 
-$(BIN_DIR)/unit_test_ascii: unit_test_ascii.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(SRC)/slow5_misc.h $(SRC)/slow5_idx.h
+$(BIN_DIR)/unit_test_ascii: unit_test_ascii.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(SRC)/slow5_misc.h $(SRC)/slow5_idx.h $(BIN_DIR)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ $(LDFLAGS)
 
-$(BIN_DIR)/unit_test_binary: unit_test_binary.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(SRC)/slow5_misc.h $(SRC)/slow5_idx.h
+$(BIN_DIR)/unit_test_binary: unit_test_binary.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(SRC)/slow5_misc.h $(SRC)/slow5_idx.h $(BIN_DIR)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ $(LDFLAGS)
 
-$(BIN_DIR)/convert_slow5_test: convert_slow5_test.c unit_test.h $(LIB)/libslow5.a
+$(BIN_DIR)/convert_slow5_test: convert_slow5_test.c unit_test.h $(LIB)/libslow5.a $(BIN_DIR)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ $(LDFLAGS)
 
-$(BIN_DIR)/unit_test_two_rg: unit_test_two_rg.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h
+$(BIN_DIR)/unit_test_two_rg: unit_test_two_rg.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(BIN_DIR)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ $(LDFLAGS)
 
-$(BIN_DIR)/unit_test_lossless: unit_test_lossless.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h
+$(BIN_DIR)/unit_test_lossless: unit_test_lossless.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(BIN_DIR)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ $(LDFLAGS)
 
-$(BIN_DIR)/unit_test_empty: unit_test_empty.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h
+$(BIN_DIR)/unit_test_empty: unit_test_empty.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(BIN_DIR)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ $(LDFLAGS)
 
-$(BIN_DIR)/unit_test_enum: unit_test_enum.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(SRC)/slow5_misc.h
+$(BIN_DIR)/unit_test_enum: unit_test_enum.c unit_test.h $(LIB)/libslow5.a $(SRC)/slow5_extra.h $(SRC)/slow5_misc.h $(BIN_DIR)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ $(LDFLAGS)
 
 clean:


### PR DESCRIPTION
As initially identified in Debian unstable, running the test suite will fail when make flags include option --shuffle=reverse.  This is symptomatic of problems of dependencies between make recipes that may materialize as failures when running the suite with a high level of parallelism.  This change ensures that the BIN_DIR is present before any attempt to write binary artifacts into it.

Bug-Debian: https://bugs.debian.org/1105533